### PR TITLE
Fix bug/json add child

### DIFF
--- a/models/sitemap/toJson.go
+++ b/models/sitemap/toJson.go
@@ -15,6 +15,7 @@ func messages(node *entity.Node) []entity.JsonMessage {
 			Referer:    m.Request.Referer(),
 			GetParams:  m.Request.URL.Query(),
 			PostParams: m.Request.PostForm,
+			URL:        m.Request.URL.Scheme + "://" + m.Request.URL.Host + m.Request.URL.Path,
 		}
 	}
 	return msg


### PR DESCRIPTION
## 概要

messages[0]によるout of indexのbug修正とjsonの改善

## 変更点

- `/path/to/page`のようなパスの時、`path`と`to`のmessagesがないことによってout of indexが発生したので修正
- jsonエクスポートの時、messagesのurl( scan時に使うフィールド )が空欄なのが気になったので埋めるように改善

## チェック項目

- [ ] 変更箇所に対するテストコードを実装しました。
- [x] 機能が正常に動作することを確認しました。

## 備考

sitemap側ではJsonNodeのURLは使ってないです。
nodeとmessagesでURLが重複してるのが気になるので、できたらcrawl側もJsonNodeに依存しないようにしてもらってJsonNode.URLを削除しちゃいたいですね