### PR TITLE
feat(err handle): エラーハンドリング用の関数を作成。エラーを追いやすいようにファイル名・行数を出力させた

### DIFF
--- a/controllers/controller.go
+++ b/controllers/controller.go
@@ -2,17 +2,16 @@ package controllers
 
 import (
 	"encoding/json"
-	"fmt"
 	"io"
 	"log"
 	"net/http"
 	"net/url"
-	"os"
 
 	"github.com/gin-gonic/gin"
 
 	"Himawari/models/crawler"
 	"Himawari/models/entity"
+	"Himawari/models/logger"
 	"Himawari/models/scanner"
 	"Himawari/models/sitemap"
 )
@@ -31,17 +30,11 @@ func UploadSitemap(c *gin.Context) {
 	sitemap.Reset()
 
 	file, err := c.FormFile("sitemap")
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-	}
+	logger.ErrHandle(err)
 	f, err := file.Open()
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-	}
+	logger.ErrHandle(err)
 	data, err := io.ReadAll(f)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-	}
+	logger.ErrHandle(err)
 	json.Unmarshal(data, &entity.JsonNodes)
 	c.String(http.StatusOK, "OK")
 }
@@ -53,8 +46,7 @@ func Crawl(c *gin.Context) {
 	sitemap.Reset()
 
 	url, err := url.Parse(c.PostForm("url"))
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
+	if logger.ErrHandle(err) {
 		return
 	}
 

--- a/main.go
+++ b/main.go
@@ -61,8 +61,8 @@ func isRunSunflower() string {
 
 func openBrowser(target string) {
 	err := browser.OpenURL(target)
-	if err != nil {
-		panic(err)
+	if logger.ErrHandle(err) {
+		//		panic(err)
 	}
 }
 

--- a/models/crawler/collectlinks.go
+++ b/models/crawler/collectlinks.go
@@ -1,13 +1,12 @@
 package crawler
 
 import (
-	"fmt"
 	"io"
 	"net/url"
-	"os"
 	"strings"
 
 	"Himawari/models/entity"
+	"Himawari/models/logger"
 
 	"github.com/PuerkitoBio/goquery"
 )
@@ -35,8 +34,7 @@ var tagUrlAttr = map[string][]string{
 
 func CollectLinks(body io.Reader, referer *url.URL) {
 	doc, err := goquery.NewDocumentFromReader(body)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
+	if logger.ErrHandle(err) {
 		return
 	}
 
@@ -55,8 +53,7 @@ func parseHtml(doc *goquery.Document, r *entity.RequestStruct) {
 				if b {
 					var err error
 					r.Path, err = url.Parse(attr)
-					if err != nil {
-						fmt.Fprintln(os.Stderr, err)
+					if logger.ErrHandle(err) {
 						return true
 					}
 					GetRequest(r)

--- a/models/crawler/forms.go
+++ b/models/crawler/forms.go
@@ -1,11 +1,10 @@
 package crawler
 
 import (
-	"fmt"
 	"net/url"
-	"os"
 
 	"Himawari/models/entity"
+	"Himawari/models/logger"
 )
 
 var testData = map[string]string{
@@ -21,8 +20,7 @@ var testData = map[string]string{
 func SetValues(form []entity.HtmlForm, r *entity.RequestStruct) {
 	r.Form.Action = form[0].Action
 	path, err := url.Parse(form[0].Action)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
+	if logger.ErrHandle(err) {
 		return
 	}
 	r.Path = path

--- a/models/scanner/auditDirListing.go
+++ b/models/scanner/auditDirListing.go
@@ -1,11 +1,10 @@
 package scanner
 
 import (
-	"fmt"
 	"net/http"
-	"os"
 
 	"Himawari/models/entity"
+	"Himawari/models/logger"
 )
 
 func auditDirListing(j *entity.JsonNode) {
@@ -17,8 +16,7 @@ func auditDirListing(j *entity.JsonNode) {
 	}
 
 	req, err := createGetReq(j.URL, "")
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
+	if logger.ErrHandle(err) {
 		return
 	}
 
@@ -26,8 +24,7 @@ func auditDirListing(j *entity.JsonNode) {
 	d.approach(d, []*http.Request{req})
 
 	reqslash, err := createGetReq(j.URL+"/", "")
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
+	if logger.ErrHandle(err) {
 		return
 	}
 	d.approach(d, []*http.Request{reqslash})

--- a/models/scanner/scannerutil.go
+++ b/models/scanner/scannerutil.go
@@ -126,8 +126,7 @@ func getSchemaPort(s string) string {
 
 func genGetParamReq(j *entity.JsonMessage, gp *url.Values) (req *http.Request, err error) {
 	req, err = createGetReq(j.URL, j.Referer)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
+	if logger.ErrHandle(err) {
 		return
 	}
 	req.URL.RawQuery = gp.Encode()
@@ -136,8 +135,7 @@ func genGetParamReq(j *entity.JsonMessage, gp *url.Values) (req *http.Request, e
 
 func genPostParamReq(j *entity.JsonMessage, pp *url.Values) (req *http.Request, err error) {
 	req, err = createPostReq(j.URL, j.Referer, *pp)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
+	if logger.ErrHandle(err) {
 		return
 	}
 	req.URL.RawQuery = j.GetParams.Encode()
@@ -194,8 +192,7 @@ func (d determinant) setKeyValues(key string, payload string, addparam bool, met
 			}
 
 			req, err := genGetParamReq(d.jsonMessage, tmpUrlValues)
-			if err != nil {
-				fmt.Fprintln(os.Stderr, err)
+			if logger.ErrHandle(err) {
 				return
 			}
 
@@ -211,8 +208,7 @@ func (d determinant) setKeyValues(key string, payload string, addparam bool, met
 			}
 
 			req, err := genPostParamReq(d.jsonMessage, tmpUrlValues)
-			if err != nil {
-				fmt.Fprintln(os.Stderr, err)
+			if logger.ErrHandle(err) {
 				return
 			}
 
@@ -228,8 +224,7 @@ func (d determinant) setHeaderDocumentRoot(payload string) {
 	d.parameter = "Path"
 	if !d.isAlreadyDetected() {
 		getPtReq, err := createGetReq(d.jsonMessage.URL, d.jsonMessage.Referer)
-		if err != nil {
-			fmt.Fprintln(os.Stderr, err)
+		if logger.ErrHandle(err) {
 			return
 		}
 		getPtReq.URL.Path = getPtReq.URL.Path + payload
@@ -245,8 +240,7 @@ func (d determinant) setGetHeader(payload string) {
 	d.parameter = "User-Agent"
 	if !d.isAlreadyDetected() {
 		getUAReq, err := createGetReq(d.jsonMessage.URL, d.jsonMessage.Referer)
-		if err != nil {
-			fmt.Fprintln(os.Stderr, err)
+		if logger.ErrHandle(err) {
 			return
 		}
 		getUAReq.Header.Set("User-Agent", getUAReq.UserAgent()+payload)
@@ -258,8 +252,7 @@ func (d determinant) setGetHeader(payload string) {
 	d.parameter = "Referer"
 	if !d.isAlreadyDetected() {
 		getRfReq, err := createGetReq(d.jsonMessage.URL, d.jsonMessage.Referer)
-		if err != nil {
-			fmt.Fprintln(os.Stderr, err)
+		if logger.ErrHandle(err) {
 			return
 		}
 		getRfReq.Header.Set("Referer", getRfReq.Referer()+payload)
@@ -275,8 +268,7 @@ func (d determinant) setPostHeader(payload string) {
 	d.parameter = "User-Agent"
 	if !d.isAlreadyDetected() {
 		postUAReq, err := createPostReq(d.jsonMessage.URL, d.jsonMessage.Referer, d.jsonMessage.PostParams)
-		if err != nil {
-			fmt.Fprintln(os.Stderr, err)
+		if logger.ErrHandle(err) {
 			return
 		}
 		postUAReq.PostForm = d.jsonMessage.PostParams
@@ -290,8 +282,7 @@ func (d determinant) setPostHeader(payload string) {
 	d.parameter = "Referer"
 	if !d.isAlreadyDetected() {
 		postRfReq, err := createPostReq(d.jsonMessage.URL, d.jsonMessage.Referer, d.jsonMessage.PostParams)
-		if err != nil {
-			fmt.Fprintln(os.Stderr, err)
+		if logger.ErrHandle(err) {
 			return
 		}
 		postRfReq.PostForm = d.jsonMessage.PostParams
@@ -305,8 +296,7 @@ func (d determinant) setPostHeader(payload string) {
 //fileにストリーム開く用
 func readfile(fn string) *os.File {
 	file, err := os.Open(fn)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
+	if logger.ErrHandle(err) {
 		os.Exit(1)
 	}
 	return file
@@ -373,19 +363,16 @@ func (d *determinant) patrol(j entity.JsonNode, randmark string) {
 			req, err = genGetParamReq(&v, &v.GetParams)
 		}
 
-		if err != nil {
-			fmt.Fprintln(os.Stderr, err)
+		if logger.ErrHandle(err) {
 			return
 		}
 
 		resp, err := client.Do(req)
-		if err != nil {
-			fmt.Fprintln(os.Stderr, err)
+		if logger.ErrHandle(err) {
 			return
 		}
 		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			fmt.Fprintln(os.Stderr, err)
+		if logger.ErrHandle(err) {
 			return
 		}
 		targetResp := string(body)
@@ -428,8 +415,7 @@ func (d determinant) setGetUA(payload string) {
 	d.parameter = "User-Agent"
 	if !d.isAlreadyDetected() {
 		getUAReq, err := createGetReq(d.jsonMessage.URL, d.jsonMessage.Referer)
-		if err != nil {
-			fmt.Fprintln(os.Stderr, err)
+		if logger.ErrHandle(err) {
 			return
 		}
 		getUAReq.Header.Set("User-Agent", getUAReq.UserAgent()+payload)
@@ -444,8 +430,7 @@ func (d determinant) setGetRef(payload string) {
 	d.parameter = "Referer"
 	if !d.isAlreadyDetected() {
 		getRfReq, err := createGetReq(d.jsonMessage.URL, d.jsonMessage.Referer)
-		if err != nil {
-			fmt.Fprintln(os.Stderr, err)
+		if logger.ErrHandle(err) {
 			return
 		}
 		getRfReq.Header.Set("Referer", getRfReq.Referer()+payload)
@@ -460,8 +445,7 @@ func (d determinant) setPostUA(payload string) {
 	d.parameter = "User-Agent"
 	if !d.isAlreadyDetected() {
 		postUAReq, err := createPostReq(d.jsonMessage.URL, d.jsonMessage.Referer, d.jsonMessage.PostParams)
-		if err != nil {
-			fmt.Fprintln(os.Stderr, err)
+		if logger.ErrHandle(err) {
 			return
 		}
 		postUAReq.PostForm = d.jsonMessage.PostParams
@@ -484,8 +468,7 @@ func (d determinant) setPostRef(payload string) {
 			postRfReq, err = createPostReq(d.jsonMessage.URL, d.jsonMessage.Referer, d.jsonMessage.PostParams)
 		}
 
-		if err != nil {
-			fmt.Fprintln(os.Stderr, err)
+		if logger.ErrHandle(err) {
 			return
 		}
 

--- a/models/sitemap/sitemap.go
+++ b/models/sitemap/sitemap.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"os"
 	"strings"
 
 	"Himawari/models/entity"
+	"Himawari/models/logger"
 )
 
 func addChild(node *entity.Node, parsedPath []string, req http.Request, time float64) {
@@ -47,8 +47,7 @@ func Add(req http.Request, time float64) {
 	// paramに `;` があるとクエリのパースでバグるため、`;` だけURLエンコード
 	req.URL.RawQuery = strings.Replace(req.URL.RawQuery, ";", "%3B", -1)
 	req.PostForm, err = url.ParseQuery(strings.Replace(req.PostForm.Encode(), ";", "%3B", -1))
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
+	if logger.ErrHandle(err) {
 		return
 	}
 
@@ -72,10 +71,10 @@ func IsExist(req http.Request) bool {
 	parsedPath = removeSpace(parsedPath)
 
 	var err error
-	//url.ParseQueryがerrの場合、中断するしかないため仕方なくtrueを返す。
 	req.URL.RawQuery = strings.Replace(req.URL.RawQuery, ";", "%3B", -1)
 	req.PostForm, err = url.ParseQuery(strings.Replace(req.PostForm.Encode(), ";", "%3B", -1))
-	if err != nil {
+	if logger.ErrHandle(err) {
+		//url.ParseQueryがerrの場合、中断するしかないため仕方なくtrueを返す。
 		return true
 	}
 


### PR DESCRIPTION
## 概要

エラーハンドリング用の関数を作成しました。
エラーを追いやすいようにファイル名・行数を出力させています。

## 変更点

leoがエラーハンドリングを整理してくれたので、置き換えただけです。

## チェック項目

- [ ] 変更箇所に対するテストコードを実装しました。
- [x] 機能が正常に動作することを確認しました。

## 再現手順

sunflwoerの`urlParseError`にパースできないhrefがあるので、そこでエラーの様子が確認できます。
VSCodeなら、ctrlクリックしたらエディタの画面がその行に飛ぶはずです。

![image](https://user-images.githubusercontent.com/51740737/140347920-809465ce-2867-402a-9535-057952d992f9.png)
