### PR TITLE
feat(crawl.vue): Crawl中のプログレスバーの表示、エラーの表示

### DIFF
--- a/webui/pages/crawl.vue
+++ b/webui/pages/crawl.vue
@@ -8,7 +8,7 @@
         dark
         dismissible
         style="position: fixed; width: 100%; z-index: 1000"
-        ><div class="font-weight-bold">Something error.</div></v-alert
+        ><div class="font-weight-bold">Something error occurred</div></v-alert
       >
     </div>
     <v-card width="50%" class="mx-auto mt-5 mb-12" style="position: relative">


### PR DESCRIPTION
## 概要

crawl時にプログレスバーを表示。
Goのapiが立ってなかったりしたらエラーも出すようにした。

## チェック項目

- [x] 機能が正常に動作することを確認しました。

## 再現手順

それぞれ以下のように再現できます

プログレスバー: delayを設定して適当にcrawl
エラー: `npm run dev`とかでwebuiだけ起動してcrawl
