### PR TITLE
fix(collectlinks): エラー処理のミス

### DIFF
--- a/api/models/crawler/collectlinks.go
+++ b/api/models/crawler/collectlinks.go
@@ -53,6 +53,9 @@ func parseHtml(doc *goquery.Document, r *entity.RequestStruct) {
 				if b {
 					var err error
 					r.Path, err = url.Parse(attr)
+					if logger.ErrHandle(err) {
+						return true
+					}
 					for key, _ := range r.Path.Query() {
 						for n, v := range applyData {
 							if key == n {
@@ -63,9 +66,6 @@ func parseHtml(doc *goquery.Document, r *entity.RequestStruct) {
 							}
 						}
 
-					}
-					if logger.ErrHandle(err) {
-						return true
 					}
 					GetRequest(r)
 				}


### PR DESCRIPTION
## 概要
- url.parseでエラーが出てしまいcrawlができないバグがありました。
url.Pars後すぐにerror処理を持ってきていないせいでnilPointerErrorが出てしまった。for文より先にerrorの処理を持ってきて解決。実際にエラーの確認ができたのはwabsepのPOSTのCASE20でVBSのschemaが原因でした。
<!--
関連するIssueがあれば、以下のように関連するIssueの番号を記述してください。
### 関連するIssue
#<issue番号>
-->

<!--
解決したIssueがある場合は、以下のように`Resolves`を付与した形で記述してください。
### 解決したIssue
Resolves #<issue番号>
-->

## 変更点
errorがあった場合のreturn処理をfor文の上に持ってきました。
<!-- 変更によりできなくなることも記述する。 -->

<!--
## 変更しなかったこと
今回のPRののスコープ外とすることがあれば記述する。
-->

## チェック項目
<!-- 必要に応じて[ ]を[x]にしてチェックを入れてください。 -->
- [x] 機能が正常に動作することを確認しました。


## 再現手順
変更前のブランチで`http://「IP」/wavsep/active/Reflected-XSS/RXSS-Detection-Evaluation-POST/Case20-Vbs2PropertyVbsScopeDoubleQuoteDelimiter.jsp`にcrawlをするとエラーが出てしまう。(Case21でも同様)
原因はVBSスキーマによるもの。
変更後のブランチでcrawlをするとエラーが出ずに終了することができる。

<!--
## 課題
悩んでいるところ、特に、レビューしてほしいところがあれば記述する。
-->

<!--
## 備考
その他補足事項があれば記述する。
-->
